### PR TITLE
Replace ~ with $HOME

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
         ${pkgs.lib.getExe winetricks} -q dotnet48 corefonts vcrun2015
         ${pkgs.lib.getExe wine} winecfg -v win11
 
-        if [ ! -d "~/.local/share/affinity/drive_c/windows/system32/WinMetadata/" ]; then
+        if [ ! -d "$HOME/.local/share/affinity/drive_c/windows/system32/WinMetadata/" ]; then
           echo "------------------------------------------------------"
           echo
           echo "Please copy the WinMetadata folder from a windows installation!"
@@ -104,7 +104,7 @@
         pkgs.writeScriptBin "install-${name}" ''
           ${pkgs.lib.getExe check} || exit 1
 
-          if [ ! -f "~/.local/share/affinity/drive_c/Program Files/Affinity/${name} 2/${name}.exe" ]; then
+          if [ ! -f "$HOME/.local/share/affinity/drive_c/Program Files/Affinity/${name} 2/${name}.exe" ]; then
               ${pkgs.lib.getExe wine} ${src}
           fi
         '';
@@ -113,7 +113,7 @@
         pkgs.writeScriptBin "run-${name}" ''
           ${pkgs.lib.getExe installer} || exit 1
 
-          ${pkgs.lib.getExe wine} "~/.local/share/affinity/drive_c/Program Files/Affinity/${name} 2/${name}.exe"
+          ${pkgs.lib.getExe wine} "$HOME/.local/share/affinity/drive_c/Program Files/Affinity/${name} 2/${name}.exe"
         '';
     in {
       wine = wine;


### PR DESCRIPTION
Tildes don't seem to get expanded to `/home/whatever` when inside quotation marks. In my case, this has caused for the WinMetadata directory check to falsely fail. Replacing it with `$HOME` fixed it. I also went and replaced all other usages of `~`.