### PR TITLE
chore: update affinity to 2.5.7

### DIFF
--- a/source.nix
+++ b/source.nix
@@ -1,19 +1,19 @@
 {requireFile}: let
-  version = "2.5.6";
+  version = "2.5.7";
 in {
   photo = requireFile {
     name = "affinity-photo-msi-${version}.exe";
-    sha256 = "0a0mhlm38pvpkkq9xbgqc94yg9y8hnwdvkmjn4hmk5pi44hwk545";
+    sha256 = "0765m6ci844kkw2wf2c8x9drizbi0h0m5kjd1z3csvhq4fiqqxys";
     url = "https://store.serif.com/en-gb/update/windows/photo/2/";
   };
   designer = requireFile {
     name = "affinity-designer-msi-${version}.exe";
-    sha256 = "0v73yq2jxgdnk5n5npr495p52535sr5z2bzk78kl7hgq0n3wbn58";
+    sha256 = "0w56kgl359qjrbrhqhwcpsdfz314cpkbmiawpps49ksb0k83ivqz";
     url = "https://store.serif.com/en-gb/update/windows/designer/2/";
   };
   publisher = requireFile {
     name = "affinity-publisher-msi-${version}.exe";
-    sha256 = "0kvixkjgh0r68f5vz6s78j7qssf8749157gidarlf6ych5ipvfmy";
+    sha256 = "1p3sifs58w86zkq1hd38p3hrnf0rj858qf0rg38l6ywv03yr2axv";
     url = "https://store.serif.com/en-gb/update/windows/designer/2/";
   };
 


### PR DESCRIPTION
Hi there!

Just recently found this repo and wanted to try it out. Unfortunately I already had a newer version of the installation files.
I hope this is correct. I used `nix-hash --type sha256 <file>` for each .exe installer.