### PR TITLE
fix(affinity-publisher): desktop item name

### DIFF
--- a/desktopItems.nix
+++ b/desktopItems.nix
@@ -36,7 +36,7 @@
   };
   publisher = makeDesktopItem {
     desktopName = "Affinity Publisher 2";
-    name = "affinity-photo";
+    name = "affinity-publisher";
     exec = "${lib.getExe publisher} %U";
     icon = fetchurl {
       url = "https://cdn.serif.com/store/img/logos/affinity-publisher-2-020520191502.svg";

--- a/flake.lock
+++ b/flake.lock
@@ -14,8 +14,8 @@
       "original": {
         "host": "gitlab.winehq.org",
         "owner": "ElementalWarrior",
+        "ref": "c12ed1469948f764817fa17efd2299533cf3fe1c",
         "repo": "wine",
-        "rev": "c12ed1469948f764817fa17efd2299533cf3fe1c",
         "type": "gitlab"
       }
     },


### PR DESCRIPTION
The desktop item for affinity-publisher was previously affinity-photo -> which then made a collision.
99% sure this was a mistake.
This fixed it for me.