### PR TITLE
fix flake lock in-fighting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,8 +149,8 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "6df24922a1400241dae323af55f30e4318a6ca65",
         "repo": "nixpkgs",
+        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,8 @@
 
   inputs = {
     # a known working revision of nixpkgs for wine. somewhat tracked by #63
-    nixpkgs-wine.url = "github:nixos/nixpkgs?ref=6df24922a1400241dae323af55f30e4318a6ca65";
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs-wine.url = "github:nixos/nixpkgs/6df24922a1400241dae323af55f30e4318a6ca65";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     on-linux = {
       url = "github:seapear/AffinityOnLinux";


### PR DESCRIPTION
there seems to be an issue with using `?ref` in flake inputs which makes Nix and Lix "fight" over the flake.lock to rename a property from `ref` <-> `rev`. using the `github:owner/repo/<ref>` URLs (instead of `github:owner/repo?ref=<ref>`) seems to prevent this.

autofix-ci seems to make commits like https://github.com/mrshmllow/affinity-nix/commit/f07c94d5771a07cb63b7010870ae49a5956b4b01 because, while we develop in lix, autofix-ci runs on nix which renames that property in the `flake.lock`.

also resolves the `error: cannot write modified lock file of flake` when running the flake ad-hoc on Lix