### PR TITLE
winehq upstream wine

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -224,7 +224,8 @@
         "nixpkgs-wine": "nixpkgs-wine",
         "on-linux": "on-linux",
         "plugin-loader": "plugin-loader",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "wine": "wine"
       }
     },
     "treefmt-nix": {
@@ -243,6 +244,25 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "type": "github"
+      }
+    },
+    "wine": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.winehq.org",
+        "lastModified": 1771620632,
+        "narHash": "sha256-Ma1lLS84aN7KCT3bOdAslDv2Cd/pUwPkKsW+KMlTnXk=",
+        "owner": "wine",
+        "repo": "wine",
+        "rev": "222c976140d1b66c71769296f856f6523782b6c9",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.winehq.org",
+        "owner": "wine",
+        "ref": "wine-11.3",
+        "repo": "wine",
+        "type": "gitlab"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -250,17 +250,17 @@
       "flake": false,
       "locked": {
         "host": "gitlab.winehq.org",
-        "lastModified": 1771620632,
-        "narHash": "sha256-Ma1lLS84aN7KCT3bOdAslDv2Cd/pUwPkKsW+KMlTnXk=",
+        "lastModified": 1775246601,
+        "narHash": "sha256-al/NlGl7upSg+vzRZvsUONfUh/4oMHb3YczDThF1AZM=",
         "owner": "wine",
         "repo": "wine",
-        "rev": "222c976140d1b66c71769296f856f6523782b6c9",
+        "rev": "6e073d28dee3af7f4c965daec94644e0f9f92727",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.winehq.org",
         "owner": "wine",
-        "ref": "wine-11.3",
+        "ref": "wine-11.6",
         "repo": "wine",
         "type": "gitlab"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,11 @@
       flake = false;
     };
 
+    wine = {
+      url = "gitlab:wine/wine?host=gitlab.winehq.org&ref=wine-11.3";
+      flake = false;
+    };
+
     flake-compat.url = "https://git.lix.systems/lix-project/flake-compat/archive/main.tar.gz";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     };
 
     wine = {
-      url = "gitlab:wine/wine?host=gitlab.winehq.org&ref=wine-11.3";
+      url = "gitlab:wine/wine?host=gitlab.winehq.org&ref=wine-11.6";
       flake = false;
     };
 

--- a/packages/wine/default.nix
+++ b/packages/wine/default.nix
@@ -17,8 +17,8 @@
           }
         ).overrideAttrs
           {
-            src = inputs.elemental-wine-source;
-            version = "9.13-part3";
+            src = inputs.wine;
+            version = "11.3";
           };
 
       symlink = pkgs.callPackage ./symlink.nix { };

--- a/packages/wine/default.nix
+++ b/packages/wine/default.nix
@@ -18,7 +18,7 @@
         ).overrideAttrs
           {
             src = inputs.wine;
-            version = "11.3";
+            version = "11.6";
           };
 
       symlink = pkgs.callPackage ./symlink.nix { };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Wine upstream to 11.6 and added support for the new source.
  * Bumped runtime revision to 9.
  * Consolidated wineboot invocation.

* **Bug Fixes / Migration**
  * Improved prefix initialization and migration handling.
  * Gate Mono/WinMetadata installation to v2 prefixes and added cleanup for older prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->