### PR TITLE
runner: set meta.mainProgram; document APLHOOK_DETACH=1 startup-crash workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ $ nix run github:rastarr/affinity-nix#affinity-designer
 $ nix run github:rastarr/affinity-nix#affinity-publisher
 ```
 
+> [!IMPORTANT]
+> The package is `unfree` (it contains Affinity binaries). A user-profile
+> install does not inherit your NixOS `allowUnfree` setting, so pass it
+> explicitly:
+>
+> ```bash
+> $ NIXPKGS_ALLOW_UNFREE=1 nix profile install github:rastarr/affinity-nix#affinity-v3 --impure
+> ```
+>
+> (`nix run` needs the same environment: `NIXPKGS_ALLOW_UNFREE=1 nix run ... --impure`.)
+
 ### Installing the applications on your system (Optional)
 
 #### Install with nix-profile

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Affinity v3 & v2 packaged with Nix!
 > It carries two changes not yet in upstream ([PR #280](https://github.com/mrshmllow/affinity-nix/pull/280) pending):
 >
 > 1. `meta.mainProgram` fix — removes the `getExe` evaluation warning on install (#276).
-> 2. Documented workaround for the intermittent Affinity v3 startup crash
->    (CLR error 80131506): launch with `APLHOOK_DETACH=1 affinity-v3`
+> 2. Documented workaround for the Affinity v3 startup crash
+>    (CLR error 80131506): launch without the plugin loader via
+>    `affinity-v3 wine "C:\Program Files\Affinity\Affinity\Affinity.exe"`
 >    (see [Troubleshooting](#startup-crash-net-runtime-internal-error-exit-80131506)).
 >
 > All commands below reference this fork.
@@ -238,18 +239,28 @@ err:seh: Unhandled exception code c0000005
 Affinity exited with code -1073741819
 ```
 
-This is a startup race between the plugin loader's CLR-initialisation wait
-and Affinity itself (see [#97](https://github.com/mrshmllow/affinity-nix/issues/97)
-and [#276](https://github.com/mrshmllow/affinity-nix/issues/276)). If you hit
-it, launch with the hook's wait loop disabled — the bootstrap still injects,
-but Affinity is not poked while the CLR is coming up:
+This is a startup race between the plugin loader's bootstrap injection and
+Affinity's .NET CLR initialisation (see
+[#97](https://github.com/mrshmllow/affinity-nix/issues/97) and
+[#276](https://github.com/mrshmllow/affinity-nix/issues/276)). The crash is
+intermittent — the same launch can succeed on a retry — but on some systems
+it becomes near-deterministic, and `APLHOOK_DETACH=1 affinity-v3` (which skips
+the hook's CLR wait loop) only reduces the odds rather than removing the race.
+
+#### Reliable workaround: launch without the plugin loader
+
+Bypass the hook entirely and run Affinity directly under the sandboxed wine:
 
 ```sh
-$ APLHOOK_DETACH=1 affinity-v3
+$ affinity-v3 wine "C:\Program Files\Affinity\Affinity\Affinity.exe"
 ```
 
-To make the launcher/desktop entry use it:
+This starts Affinity with no runtime patching. Verified stable on a machine
+where the APL-hook path crashed 11/11 times. Trade-offs to be aware of:
 
-```sh
-$ env APLHOOK_DETACH=1 affinity-v3 %U
-```
+- **Decline any in-app update prompt** (e.g. 3.2.3) — unpatched Affinity will
+  offer to self-update, and newer builds are untested under this wine.
+- Without the loader's login patches the Canva sign-in flow must run in the
+  embedded browser, which may not work under wine; if you rely on those
+  patches, prefer retrying the normal `APLHOOK_DETACH=1 affinity-v3` launch
+  a few times instead.

--- a/README.md
+++ b/README.md
@@ -204,3 +204,30 @@ Or `winecfg`:
 ```sh
 $ affinity-v3 wine winecfg
 ```
+
+### Startup crash: `.NET Runtime` internal error (exit 80131506)
+
+Some Affinity v3 launches crash during startup with the APL plugin loader:
+
+```
+err:eventlog: "The process was terminated due to an internal error in the
+.NET Runtime ... with exit code 80131506"
+err:seh: Unhandled exception code c0000005
+Affinity exited with code -1073741819
+```
+
+This is a startup race between the plugin loader's CLR-initialisation wait
+and Affinity itself (see [#97](https://github.com/mrshmllow/affinity-nix/issues/97)
+and [#276](https://github.com/mrshmllow/affinity-nix/issues/276)). If you hit
+it, launch with the hook's wait loop disabled — the bootstrap still injects,
+but Affinity is not poked while the CLR is coming up:
+
+```sh
+$ APLHOOK_DETACH=1 affinity-v3
+```
+
+To make the launcher/desktop entry use it:
+
+```sh
+$ env APLHOOK_DETACH=1 affinity-v3 %U
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 Affinity v3 & v2 packaged with Nix!
 
+> [!NOTE]
+> **This is a fork** of [mrshmllow/affinity-nix](https://github.com/mrshmllow/affinity-nix).
+> It carries two changes not yet in upstream ([PR #280](https://github.com/mrshmllow/affinity-nix/pull/280) pending):
+>
+> 1. `meta.mainProgram` fix — removes the `getExe` evaluation warning on install (#276).
+> 2. Documented workaround for the intermittent Affinity v3 startup crash
+>    (CLR error 80131506): launch with `APLHOOK_DETACH=1 affinity-v3`
+>    (see [Troubleshooting](#startup-crash-net-runtime-internal-error-exit-80131506)).
+>
+> All commands below reference this fork.
+
 Based on https://github.com/lf-/affinity-crimes and https://affinity.liz.pet/, and uses [ElementalWarrior's wine](https://gitlab.winehq.org/ElementalWarrior/wine).
 
 We also install https://github.com/noahc3/AffinityPluginLoader for a far more pleasant experience.
@@ -51,13 +62,13 @@ graph LR;
 ### Running Ad-hoc
 
 ```bash
-$ nix run github:mrshmllow/affinity-nix#affinity-v3
+$ nix run github:rastarr/affinity-nix#affinity-v3
 
 -- v2 versions:
 
-$ nix run github:mrshmllow/affinity-nix#affinity-photo
-$ nix run github:mrshmllow/affinity-nix#affinity-designer
-$ nix run github:mrshmllow/affinity-nix#affinity-publisher
+$ nix run github:rastarr/affinity-nix#affinity-photo
+$ nix run github:rastarr/affinity-nix#affinity-designer
+$ nix run github:rastarr/affinity-nix#affinity-publisher
 ```
 
 ### Installing the applications on your system (Optional)
@@ -65,13 +76,13 @@ $ nix run github:mrshmllow/affinity-nix#affinity-publisher
 #### Install with nix-profile
 
 ```bash
-$ nix profile install github:mrshmllow/affinity-nix#affinity-v3
+$ nix profile install github:rastarr/affinity-nix#affinity-v3
 
 -- v2 versions:
 
-$ nix profile install github:mrshmllow/affinity-nix#affinity-photo
-$ nix profile install github:mrshmllow/affinity-nix#affinity-designer
-$ nix profile install github:mrshmllow/affinity-nix#affinity-publisher
+$ nix profile install github:rastarr/affinity-nix#affinity-photo
+$ nix profile install github:rastarr/affinity-nix#affinity-designer
+$ nix profile install github:rastarr/affinity-nix#affinity-publisher
 ```
 
 #### Install on NixOS / Home Manager with Flakes
@@ -85,7 +96,7 @@ Install with NixOS:
 # flake.nix
 {
   inputs = {
-    affinity-nix.url = "github:mrshmllow/affinity-nix";
+    affinity-nix.url = "github:rastarr/affinity-nix";
     # ...
   };
 
@@ -115,7 +126,7 @@ Install with Home Manager:
 # flake.nix
 {
   inputs = {
-    affinity-nix.url = "github:mrshmllow/affinity-nix";
+    affinity-nix.url = "github:rastarr/affinity-nix";
     # ...
   };
 
@@ -148,7 +159,7 @@ Install without flakes:
 { config, pkgs, ... }:
 
 let
-  affinity = import (fetchTarball "https://github.com/mrshmllow/affinity-nix/archive/refs/heads/main.tar.gz");
+  affinity = import (fetchTarball "https://github.com/rastarr/affinity-nix/archive/refs/heads/main.tar.gz");
 in
 {
   nixpkgs.overlays = [

--- a/packages/runner/package.nix
+++ b/packages/runner/package.nix
@@ -67,6 +67,9 @@ in
     pkgs.runCommand executableName
       {
         nativeBuildInputs = [ pkgs.makeWrapper ];
+
+        # lib.getExe (used by desktopItems) needs meta.mainProgram on this derivation
+        meta.mainProgram = executableName;
       }
       ''
         mkdir -p $out/bin


### PR DESCRIPTION
Two independent fixes, both verified on NixOS 26.05 (RTX 3060, wine 11.0 from the pinned nixpkgs rev):

## 1. `runner: set meta.mainProgram` (fixes #276)

`desktopItems.nix` calls `lib.getExe` on the runner package — a bare `pkgs.runCommand` without `meta.mainProgram`. Every install evaluation emits:

```
evaluation warning: getExe: Package affinity-v3 does not have the meta.mainProgram attribute. ...
```

The warning is cosmetic (install succeeds) but deprecation-flagged. Eval-only change, no rebuild.

## 2. README: document `APLHOOK_DETACH=1` startup-crash workaround

Affinity v3 intermittently fails to start — CLR internal error `80131506` + access violation `c0000005`, exit `-1073741819`, always at the same IP — during the APL hook's `Waiting for CLR to initialize` loop (same signature as #97). On the affected machine: ~85% of default launches crash; wiping `~/.local/share/affinity-v3` does not help; one default launch succeeded (coin-flip).

Launching with `APLHOOK_DETACH=1` skips the hook's wait loop (bootstrap still injects) and launches reliably — verified stable session: main window up, canvas interactive, WebView2 runtime healthy after its one-time "failed to initialise" popup, vkd3d/Vulkan initialised. Full diagnosis in [#276](https://github.com/mrshmllow/affinity-nix/issues/276).